### PR TITLE
Document Firebase config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ yarn
 
 - Go to the Project Overview and find `Get started by adding Firebase to your app` click to `web`.
 - Register an app and you will get your config.
-- You need to replace config in app's directory `services/firebase/config.js` with your config.
+- Copy `services/firebase/config.example.js` to `services/firebase/config.js` and paste your Firebase web config into the new file. The `config.js` file is ignored by Git so your credentials stay local.
 
 ``` bash
 apiKey: 'YOUR_CONFIG',

--- a/services/firebase/config.example.js
+++ b/services/firebase/config.example.js
@@ -1,0 +1,10 @@
+export const config = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_PROJECT.firebaseapp.com',
+  databaseURL: 'https://YOUR_PROJECT.firebaseio.com',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_PROJECT.appspot.com',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+  measurementId: 'YOUR_MEASUREMENT_ID',
+}


### PR DESCRIPTION
## Summary
- document how to create a Firebase config from the provided example file
- add a checked-in `services/firebase/config.example.js` placeholder so developers can copy it locally

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174281507c832ebfc768a007550e2b)