### PR TITLE
Added filter on (words in) description

### DIFF
--- a/locales/en-US.js
+++ b/locales/en-US.js
@@ -300,6 +300,7 @@ export default {
     more: 'Show more',
     filter: {
       showTrnsWithDesc: 'Only with description',
+      descriptionSearchPlaceholder: 'Search in description...',
     },
     noTrns: 'No transactions',
   },

--- a/locales/ru-RU.js
+++ b/locales/ru-RU.js
@@ -241,6 +241,7 @@ export default {
     more: 'Показать еще',
     filter: {
       showTrnsWithDesc: 'Только с описанием',
+      descriptionSearchPlaceholder: 'Поиск по описанию...',
     },
     noTrns: 'Нет транзакций',
   },


### PR DESCRIPTION
Implemented in [List.vue]:

* Added `descriptionFilter` input shown when `Only with description` is enabled.
* Split input into words (`descriptionFilterWords`) by whitespace.
* Filter logic now requires **all entered words** to be present in each transaction description (`desc` or `description`), case-insensitive.
* Kept existing behavior: with toggle enabled and empty search, it still shows all transactions that have any description.
* Clears the search input when the toggle is turned off.

Locale updates:

[en-US.js]: added `trns.filter.descriptionSearchPlaceholder` (Search in description...)
[ru-RU.js]: added `trns.filter.descriptionSearchPlaceholder` (Поиск по описанию...)