### PR TITLE
Re-enabled duplication of trns

### DIFF
--- a/components/trnForm/useTrnForm.ts
+++ b/components/trnForm/useTrnForm.ts
@@ -299,7 +299,6 @@ export function useTrnForm() {
 
   function trnFormDuplicate(trnId: TrnId) {
     const trn = $store.state.trns.items[trnId]
-    console.log('trnId', trnId)
 
     $trnForm.setValues({
       action: 'duplicate',

--- a/components/trns/item/Modal.vue
+++ b/components/trns/item/Modal.vue
@@ -79,7 +79,6 @@ export default {
 
     handleDuplicateTrn() {
       const trnId = this.trnId
-      console.log('trnId', trnId)
       this.trnFormDuplicate(trnId)
       this.$store.commit('trns/hideTrnModal')
       this.$store.commit('trns/setTrnModalId', null)
@@ -175,7 +174,6 @@ Portal(
             )
 
             ModalButton(
-              v-if="false"
               :name="$t('base.duplicate')"
               icon="mdi mdi-content-copy"
               @onClick="handleDuplicateTrn"


### PR DESCRIPTION
Implemented the **Duplicate** action in the transaction modal.

#### What changed
* Enabled the duplicate button in [Modal.vue (line 177)] by removing the hardcoded `v-if="false"`.
* Kept the action wired to existing duplicate flow (`handleDuplicateTrn` -> `trnFormDuplicate`) in [Modal.vue (line 80)].
* Removed debug logging from duplicate handlers:
  * [Modal.vue (line 81)]
  * [useTrnForm.ts (line 300)]

#### Behavior now
Clicking **Duplicate** from the transaction modal opens the transaction form in create mode with values prefilled from the selected transaction (using the existing `trnFormDuplicate` + [setValues({ action: 'duplicate', ... })] logic).